### PR TITLE
fix command lark default-env, now supports any string as an environment

### DIFF
--- a/lib/commands/default.js
+++ b/lib/commands/default.js
@@ -2,34 +2,40 @@
 
 var program = require('commander');
 
+var shortMap = {
+    'production':  ['pro', 'prod', 'product'],
+    'development': ['dev', 'develop']
+};
+
 module.exports = function (move_to_app_root) {
     function defualt_env (env) {
         var larkInfo = move_to_app_root();
-        if ('string' === typeof env) {
+        if ('string' === typeof env && env.length > 0) {
             var set = true;
         }
         else {
             env = larkInfo('env');
         }
-        if (env === 'production' || env === 'prod') {
-            env = 'production';
-            console.log("Default env is " + (set ? "set to " : "") + env);
-            set && larkInfo('env', env);
-        }
-        else if (env === 'development' || env === 'dev') {
-            env = 'development';
-            console.log("Default env is " + (set ? "set to " : "") + env);
-            set && larkInfo('env', env);
-        }
-        else {
-            if (set && env === 'clear') {
-                console.log("Default env is cleared");
-                larkInfo('env', null);
+        for (var name in shortMap) {
+            var alias = Array.isArray(shortMap[name]) ? shortMap[name] : [shortMap[name]];
+            if (alias.indexOf(env) >= 0) {
+                env = name;
+                break;
             }
-            else {
-                console.log(set ? "Invalid default env, must be production|prod|development|dev" : "Default env is not set yet");
-            }
+        };
+        if (set && env === 'clear') {
+            console.log("Default env is cleared");
+            larkInfo('env', null);
+            return;
         }
+        if (set) {
+            larkInfo('env', env);
+            env = '[' + env + ']';
+        }
+        else if (!env) {
+            env = 'not set yet';
+        }
+        console.log("Default env is " + (set ? "set to " : "") + env);
     }
 
     /**

--- a/lib/commands/status.js
+++ b/lib/commands/status.js
@@ -16,7 +16,9 @@ module.exports = function (move_to_app_root) {
                 var list = arguments[1];
                 var disp = require('lark-bootstrap/node_modules/pm2/lib/CliUx').dispAsTable;
                 disp(list);
-                process.exit(0);
+                setTimeout(function () {
+                    process.exit(0);
+                },10);
             });
         });
 };


### PR DESCRIPTION
之前只支持 `lark default-env {env}` 只支持 `env` 的值是 `production` 或者 `development` ，现在增加了对任意字符串的支持，即 `lark default-env foobar` 这类。