### PR TITLE
Post

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -32,8 +32,13 @@ var DEFAULT_PORT = 3000;
  * default return true
  */
 var enable = function (config, key, defaultValue) {
-    false === defaultValue || (defaultValue = true);
-    var result = !(typeof config === 'object' && typeof key === 'string' && config[key] && config[key].enable || defaultValue === false);
+    if (false !== defaultValue) {
+        defaultValue = true;
+    }
+    var result = defaultValue;
+    if (typeof config === 'object' && typeof key === 'string' && config[key] && 'boolean' === typeof config[key].enable) {
+        result = config[key].enable;
+    }
     debug('middleware:', key, 'enable', result);
     return result;
 };

--- a/lib/application.js
+++ b/lib/application.js
@@ -20,6 +20,7 @@ var views = require('lark-views');
 var debug = require('debug')('lark:application');
 var clone = require('clone');
 var bootstrap = require('./bootstrap');
+var parsers = require('./parsers');
 var DEFAULT_PORT = 3000;
 
 /**
@@ -31,13 +32,8 @@ var DEFAULT_PORT = 3000;
  * default return true
  */
 var enable = function (config, key, defaultValue) {
-    if (false !== defaultValue) {
-        defaultValue = true;
-    }
-    var result = defaultValue;
-    if (typeof config === 'object' && typeof key === 'string' && config[key] && 'boolean' === typeof config[key].enable) {
-        result = config[key].enable;
-    }
+    false === defaultValue || (defaultValue = true);
+    var result = !(typeof config === 'object' && typeof key === 'string' && config[key] && config[key].enable || defaultValue === false);
     debug('middleware:', key, 'enable', result);
     return result;
 };
@@ -58,11 +54,15 @@ function Application(options) {
     if (!(this instanceof Application)) {
         return new Application(options);
     }
+    /**
+     * Extend Koa
+     **/
     koa.call(this);
     this.config = config(options);
     if (enable(this.config, 'logging')){
         logging.logging.configure(this.config.logging);
     }
+    parsers(this, this.config.parsers);
 }
 
 util.inherits(Application, koa);
@@ -111,7 +111,6 @@ app.run = function (port, callback) {
 
     this.use(configMiddleware(configs))
         .use(require('koa-static')('./statics', this.config.static))
-        .use(require('koa-bodyparser')());
     if (enable(configs, 'logging')){
         this.use(logging.middleware(configs.logging)); 
     }

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -1,0 +1,157 @@
+/**
+ * lark.js - lib/parsers.js
+ * Copyright(c) 2015 larkjs-team
+ * MIT Licensed
+ */
+
+'use strict';
+
+var extend = require('extend');
+var path   = require('path');
+var bodyParsers = require('koa-body-parsers');
+var Readable = require('stream').Readable;
+
+module.exports = function (app, oriConfig) {
+    bodyParsers(app);
+
+    var config = makeConfig(oriConfig);
+    if (config.enable) {
+        return;
+    }
+
+    app.request.body = function * (options) {
+        var request = this;
+        if (request._parsers_body) {
+            return request._parsers_body;
+        }
+        var body;
+        var detailedType = request.get('content-type');
+        var type = request.is.apply(request, Object.keys(config.types));
+        if (!type || 'string' !== typeof type) {
+            return;
+        }
+        if (type.match(/^image\//)) {
+            type = 'image/*';
+        }
+        var typeConfig = config.types[type];
+        if (!typeConfig || typeConfig.enable === false) {
+            return;
+        }
+        switch (type) {
+            case 'json' :
+            case 'urlencoded' :
+            case 'text' :
+            case 'buffer' :
+                body = yield request[type](typeConfig.limit);
+                break;
+            case 'image/*' :
+                var extname = detailedType.split('/')[1];
+                request.req.mime = request.req.mimeType = detailedType;
+                request.req.name = request.req.name || 'upload_image';
+                request.req.filename = request.req.filename || 'upload_image.' + extname;
+                if (request.saveAs) {
+                    body = yield save(app, request.saveAs, request.req);
+                }
+                else {
+                    body = yield readable2buffer(request.req);
+                }
+                break;
+            case 'multipart' :
+                var parts = request.parts(typeConfig);
+                var kv = {};
+                var part;
+                var count = 0;
+                while (part = yield parts) {
+                    count++;
+                    if (Array.isArray(part)) {
+                        var key = part[0] || 'key' + count;
+                        var value = part[1];
+                    }
+                    else {
+                        var key = part.fieldname || 'file' + count;
+                        var value = {
+                            filename: part.filename,
+                            name: part.fieldname,
+                            mime: part.mime,
+                            mimeType: part.mimeType,
+                        };
+                        if (request.saveAs) {
+                            value.save = yield save(app, request.saveAs, part);
+                        }
+                        else {
+                            value.content = yield readable2buffer(part);
+                        }
+                    }
+                    if (kv[key] !== undefined) {
+                        var error = new Error('Duplicated keys');
+                        error.status = 400;
+                        throw error;
+                    }
+                    kv[key] = value;
+                }
+                body = kv;
+                break;
+            default:
+                break;
+        }
+        request._parsers_body = body;
+        return request._parsers_body;
+    };
+}
+
+var TYPES = ['json','urlencoded','text','buffer','multipart','image/*'];
+
+function makeConfig (oriConfig) {
+    var config = {
+        types: {},
+    };
+
+    if (!oriConfig || oriConfig.enable === false || !(oriConfig.types instanceof Object)) {
+        config.enable = false;
+        return config;
+    }
+
+    TYPES.forEach(function (type) {
+        var itemConfig = extend(true, extend(true , {}, oriConfig.types['*']), oriConfig.types[type] || {});
+        config.types[type] = itemConfig;
+    });
+
+    if (Object.keys(config.types).length <= 0) {
+        config.enable = false;
+        return config;
+    }
+
+    return config;
+}
+
+function * readable2buffer (readable) {
+    if (!(readable instanceof Readable)) {
+        throw new Error('Param readable must be an instance of Readable!');
+    }
+    return new Promise (function (resolve, reject) {
+        var buffer = [];
+        readable.on('data', function (chunk) {
+            buffer.push(chunk);
+        });
+        readable.on('end', function () {
+            buffer = Buffer.concat(buffer);
+            return resolve(buffer);
+        });
+        readable.on('error', function (e) {
+            return reject(e);
+        });
+    });
+}
+
+var rootPath = path.dirname(process.mainModule.filename);
+function * save (app, saveAs, readable) {
+    if (!(saveAs instanceof Function)) {
+        throw new Error('saveAs should be a function to generate save path');
+    }
+    var savePath = path.join(rootPath, saveAs(readable));
+    if (savePath.slice(0, rootPath.length) !== rootPath) {
+        throw new Error('Error permission denied!');
+    }
+    yield app.context.save(readable, savePath);
+    return savePath;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lark",
-  "version": "0.11.4",
+  "version": "0.12.0",
   "description": "A node.js framework based on koa. Our goal is to build the best industrial node.js framework for high concurrency and high flow application. ",
   "scripts": {
     "test": "NODE_ENV=development ./node_modules/.bin/mocha --harmony --require should test/",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/larkjs/lark.git"
+    "url": "git+https://github.com/larkjs/lark.git"
   },
   "keywords": [
     "node",
@@ -42,9 +42,10 @@
     "router.js"
   ],
   "dependencies": {
+    "extend": "~3.0.0",
     "koa": "^0.20.0",
     "koa-static": "~1.4.9",
-    "koa-bodyparser": "~2.0.0",
+    "koa-body-parsers": "~1.1.0",
     "lark-bootstrap": "~0.2.0",
     "lark-config": "~0.4.4",
     "lark-commands": "~0.1.1",
@@ -70,5 +71,39 @@
     "got": "^3.0.0",
     "debug": "^2.1.3",
     "fecs": "~0.4.1"
-  }
+  },
+  "gitHead": "266abab845fb9ece90c933a49f7861e05ae1b159",
+  "_id": "lark@0.11.4",
+  "_shasum": "50613c245dff0202e33ce6dc23089cbecf6c7548",
+  "_from": "lark@0.11.4",
+  "_npmVersion": "2.0.0",
+  "_npmUser": {
+    "name": "viringbells",
+    "email": "viringbells@qq.com.cn"
+  },
+  "dist": {
+    "shasum": "50613c245dff0202e33ce6dc23089cbecf6c7548",
+    "tarball": "http://registry.npmjs.org/lark/-/lark-0.11.4.tgz"
+  },
+  "maintainers": [
+    {
+      "name": "zhangyuanwei",
+      "email": "zhangyuanwei1988@gmail.com"
+    },
+    {
+      "name": "mdemo",
+      "email": "mengdesen09@qq.com"
+    },
+    {
+      "name": "zezhou",
+      "email": "xuyizhi@gmail.com"
+    },
+    {
+      "name": "viringbells",
+      "email": "viringbells@qq.com.cn"
+    }
+  ],
+  "directories": {},
+  "_resolved": "https://registry.npmjs.org/lark/-/lark-0.11.4.tgz",
+  "readme": "ERROR: No README data found!"
 }


### PR DESCRIPTION
增加了对多种类型post数据的支持，

现在可以使用[https://github.com/koajs/koala/blob/master/docs/body-parsing.md#content-negotiation](https://github.com/koajs/koala/blob/master/docs/body-parsing.md#content-negotiation)这个方式来进行处理post数据。

同时将上面的方案集成到了`lark`中，具体方案如下：

增加`* this.request.body()`函数，在启用parser的情况下，`yield this.request.body()`能根据数据的类型做处理，返回对应的结果。

不过由于`image/*`和`multipart`类型中会有文件，`yield this.request.body()`会将这些文件转换成`Buffer`，可能会造成内存占用过高。

所以对于这种情况，既可以通过配置的方式disable掉parse的工作，直接对stream进行操作，也可以在调用`yield this.request.body()`前设置`this.request.saveAs = function (readabel) { ... }`来设置保存的路径计算方式，这样`lark`会自行将上传对文件按照`saveAs`计算的路径保存到本地

_方案效果_

```
router.post('/', function *(next) {
    this.request.saveAs = function (readable) {
        return 'upload/' + readable.filename;
    };
    var postData = yield this.request.body();
    console.log(postData);
    this.body = 'UPLOAD OK!';
    yield next;
});
```

_结果_

```
{
  name: 'another',
  userfile: 
  {
    filename: 'haha.jpg',
    name: 'userfile',
    mime: 'image/jpeg',
    mimeType: 'image/jpeg',
    save: '/Users/mbu-se-vc/haohao/projects/appPost/upload/haha.jpg' 
  },
  type: 'image'
 }
```

@zezhou 看看方案是否ok